### PR TITLE
updated to 11.0.0-preview5

### DIFF
--- a/AvaloniaProgressRing/AvaloniaProgressRing.csproj
+++ b/AvaloniaProgressRing/AvaloniaProgressRing.csproj
@@ -27,7 +27,7 @@
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview2" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview5" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\LICENSE.md">

--- a/AvaloniaProgressRing/ProgressRing.cs
+++ b/AvaloniaProgressRing/ProgressRing.cs
@@ -41,7 +41,7 @@ namespace AvaloniaProgressRing
         public static readonly StyledProperty<bool> IsActiveProperty =
             AvaloniaProperty.Register<ProgressRing, bool>(nameof(IsActive), defaultValue: true, notifying: OnIsActiveChanged);
 
-        private static void OnIsActiveChanged(IAvaloniaObject obj, bool arg2)
+        private static void OnIsActiveChanged(AvaloniaObject obj, bool arg2)
         {
             ((ProgressRing)obj).UpdateVisualStates();
         }

--- a/AvaloniaProgressRingSample/App.xaml
+++ b/AvaloniaProgressRingSample/App.xaml
@@ -1,10 +1,9 @@
 ﻿<Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:progring="clr-namespace:AvaloniaProgressRing;assembly=AvaloniaProgressRing"
              x:Class="AvaloniaProgressRingSample.App">
     <Application.Styles>
-        <SimpleTheme Mode="Light" />
-        <StyleInclude Source="avares://Avalonia.Themes.Simple/Accents/BaseLight.xaml"/>
+        <SimpleTheme/>
+
         <StyleInclude Source="avares://AvaloniaProgressRing/Styles/ProgressRing.xaml"/>
     </Application.Styles>
 </Application>

--- a/AvaloniaProgressRingSample/AvaloniaProgressRingSample.csproj
+++ b/AvaloniaProgressRingSample/AvaloniaProgressRingSample.csproj
@@ -12,12 +12,12 @@
     </AvaloniaResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview2" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview2" />
-    <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-preview2" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview5" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview5" />
+    <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-preview5" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview2" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AvaloniaProgressRing\AvaloniaProgressRing.csproj" />


### PR DESCRIPTION
Hi, after update to Avalonia-11.0.0-preview5 comes this error:

![grafik](https://user-images.githubusercontent.com/41585619/216900359-f8173712-135d-4710-9879-77ef99d9bda3.png)

This is because the delegate has been changed from IAvaloniaObject to AvaloniaObject:

![grafik](https://user-images.githubusercontent.com/41585619/216900938-f0e28274-f89a-4a02-97f9-8bd654cc89c7.png)

The behavior of the theming has also changed. The light/dark is automatically detected and set unless you set it.
I made the necessary changes to make it compatible with Avalonia-11.0.0-preview5. 