### PR TITLE
Avalonia 11 preview-6 update

### DIFF
--- a/AvaloniaProgressRing/AvaloniaProgressRing.csproj
+++ b/AvaloniaProgressRing/AvaloniaProgressRing.csproj
@@ -27,7 +27,7 @@
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview5" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\LICENSE.md">

--- a/AvaloniaProgressRing/Internals/SimpleObserver.cs
+++ b/AvaloniaProgressRing/Internals/SimpleObserver.cs
@@ -1,0 +1,29 @@
+﻿// ReSharper disable once CheckNamespace
+
+using Avalonia;
+using System;
+
+namespace AvaloniaProgressRing
+{
+	internal sealed class SimpleObserver<TOwner, T> : IObserver<T>
+		where TOwner : AvaloniaObject
+	{
+		private readonly TOwner _owner;
+		private readonly Action<TOwner, T> _listener;
+
+		public SimpleObserver(TOwner owner, Action<TOwner, T> listener)
+		{
+			_owner = owner ?? throw new ArgumentNullException(nameof(owner));
+			_listener = listener ?? throw new ArgumentNullException(nameof(listener));
+		}
+
+		public void OnCompleted()
+		{ }
+
+		public void OnError(Exception error)
+		{ }
+
+		public void OnNext(T value)
+			=> _listener(_owner, value);
+	}
+}

--- a/AvaloniaProgressRing/ProgressRing.cs
+++ b/AvaloniaProgressRing/ProgressRing.cs
@@ -1,111 +1,105 @@
 ﻿using Avalonia;
 using Avalonia.Controls.Primitives;
-using Avalonia.Media;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace AvaloniaProgressRing
 {
-    public class ProgressRing : TemplatedControl
-    {
-        private const string LargeState = ":large";
-        private const string SmallState = ":small";
+	public class ProgressRing : TemplatedControl
+	{
+		private const string LargeState = ":large";
+		private const string SmallState = ":small";
 
-        private const string InactiveState = ":inactive";
-        private const string ActiveState = ":active";
+		private const string InactiveState = ":inactive";
+		private const string ActiveState = ":active";
 
-        private double _maxSideLength = 10;
-        private double _ellipseDiameter = 10;
-        private Thickness _ellipseOffset = new Thickness(2);
+		private double _maxSideLength = 10;
+		private double _ellipseDiameter = 10;
+		private Thickness _ellipseOffset = new Thickness(2);
 
-        static ProgressRing()
-        {
-            //DefaultStyleKeyProperty.OverrideMetadata(typeof(ProgressRing),
-            //    new FrameworkPropertyMetadata(typeof(ProgressRing)));
-        }
+		private IObserver<AvaloniaPropertyChangedEventArgs> _isActiveChangedObserver;
 
-        public ProgressRing()
-        {
-        }
+		#region IsActive
 
-        #region IsActive
+		public static readonly StyledProperty<bool> IsActiveProperty =
+			AvaloniaProperty.Register<ProgressRing, bool>(
+				nameof(IsActive),
+				defaultValue: true);
 
-        public bool IsActive
-        {
-            get => (bool)GetValue(IsActiveProperty);
-            set => SetValue(IsActiveProperty, value);
-        }
+		public bool IsActive
+		{
+			get => GetValue(IsActiveProperty);
+			set => SetValue(IsActiveProperty, value);
+		}
 
+		public static readonly DirectProperty<ProgressRing, double> MaxSideLengthProperty =
+			AvaloniaProperty.RegisterDirect<ProgressRing, double>(
+			   nameof(MaxSideLength),
+			   o => o.MaxSideLength);
 
-        public static readonly StyledProperty<bool> IsActiveProperty =
-            AvaloniaProperty.Register<ProgressRing, bool>(nameof(IsActive), defaultValue: true, notifying: OnIsActiveChanged);
+		public double MaxSideLength
+		{
+			get => _maxSideLength;
+			private set => SetAndRaise(MaxSideLengthProperty, ref _maxSideLength, value);
+		}
 
-        private static void OnIsActiveChanged(AvaloniaObject obj, bool arg2)
-        {
-            ((ProgressRing)obj).UpdateVisualStates();
-        }
+		public static readonly DirectProperty<ProgressRing, double> EllipseDiameterProperty =
+			AvaloniaProperty.RegisterDirect<ProgressRing, double>(
+			   nameof(EllipseDiameter),
+			   o => o.EllipseDiameter);
 
-        public static readonly DirectProperty<ProgressRing, double> MaxSideLengthProperty =
-            AvaloniaProperty.RegisterDirect<ProgressRing, double>(
-               nameof(MaxSideLength),
-               o => o.MaxSideLength);
+		public double EllipseDiameter
+		{
+			get => _ellipseDiameter;
+			private set => SetAndRaise(EllipseDiameterProperty, ref _ellipseDiameter, value);
+		}
 
-        public double MaxSideLength
-        {
-            get { return _maxSideLength; }
-            private set { SetAndRaise(MaxSideLengthProperty, ref _maxSideLength, value); }
-        }
+		public static readonly DirectProperty<ProgressRing, Thickness> EllipseOffsetProperty =
+			AvaloniaProperty.RegisterDirect<ProgressRing, Thickness>(
+			   nameof(EllipseOffset),
+			   o => o.EllipseOffset);
 
-        public static readonly DirectProperty<ProgressRing, double> EllipseDiameterProperty =
-            AvaloniaProperty.RegisterDirect<ProgressRing, double>(
-               nameof(EllipseDiameter),
-               o => o.EllipseDiameter);
+		public Thickness EllipseOffset
+		{
+			get => _ellipseOffset;
+			private set => SetAndRaise(EllipseOffsetProperty, ref _ellipseOffset, value);
+		}
 
-        public double EllipseDiameter
-        {
-            get { return _ellipseDiameter; }
-            private set { SetAndRaise(EllipseDiameterProperty, ref _ellipseDiameter, value); }
-        }
+		#endregion
 
-        public static readonly DirectProperty<ProgressRing, Thickness> EllipseOffsetProperty =
-            AvaloniaProperty.RegisterDirect<ProgressRing, Thickness>(
-               nameof(EllipseOffset),
-               o => o.EllipseOffset);
+		protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+		{
+			base.OnApplyTemplate(e);
 
-        public Thickness EllipseOffset
-        {
-            get { return _ellipseOffset; }
-            private set { SetAndRaise(EllipseOffsetProperty, ref _ellipseOffset, value); }
-        }
+			double maxSideLength = Math.Min(this.Width, this.Height);
+			double ellipseDiameter = 0.1 * maxSideLength;
+			if (maxSideLength <= 40)
+			{
+				ellipseDiameter += 1;
+			}
 
-        #endregion
+			EllipseDiameter = ellipseDiameter;
+			MaxSideLength = maxSideLength;
+			EllipseOffset = new Thickness(0, maxSideLength / 2 - ellipseDiameter, 0, 0);
 
+			UpdateVisualStates();
 
-        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
-        {
-            base.OnApplyTemplate(e);
-            double maxSideLength = Math.Min(this.Width, this.Height);
-            double ellipseDiameter = 0.1 * maxSideLength;
-            if (maxSideLength <= 40)
-            {
-                ellipseDiameter += 1;
-            }
+			if (_isActiveChangedObserver is null)
+			{
+				_isActiveChangedObserver = new SimpleObserver<ProgressRing, AvaloniaPropertyChangedEventArgs>(this, (pr, _) => pr.UpdateVisualStates());
 
-            EllipseDiameter = ellipseDiameter;
-            MaxSideLength = maxSideLength;
-            EllipseOffset = new Thickness(0, maxSideLength / 2 - ellipseDiameter, 0, 0);
-            UpdateVisualStates();
-        }
+				this.GetPropertyChangedObservable(ProgressRing.IsActiveProperty)
+					.Subscribe(_isActiveChangedObserver);
+			}
+		}
 
-        private void UpdateVisualStates()
-        {
-            PseudoClasses.Remove(ActiveState);
-            PseudoClasses.Remove(InactiveState);
-            PseudoClasses.Remove(SmallState);
-            PseudoClasses.Remove(LargeState);
-            PseudoClasses.Add(IsActive ? ActiveState : InactiveState);
-            PseudoClasses.Add(_maxSideLength < 60 ? SmallState : LargeState);
-        }
-    }
+		private void UpdateVisualStates()
+		{
+			PseudoClasses.Remove(ActiveState);
+			PseudoClasses.Remove(InactiveState);
+			PseudoClasses.Remove(SmallState);
+			PseudoClasses.Remove(LargeState);
+			PseudoClasses.Add(IsActive ? ActiveState : InactiveState);
+			PseudoClasses.Add(_maxSideLength < 60 ? SmallState : LargeState);
+		}
+	}
 }

--- a/AvaloniaProgressRingSample/AvaloniaProgressRingSample.csproj
+++ b/AvaloniaProgressRingSample/AvaloniaProgressRingSample.csproj
@@ -12,12 +12,12 @@
     </AvaloniaResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview5" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview5" />
-    <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-preview5" />
+    <PackageReference Include="Avalonia" Version="11.0.0-preview6" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview6" />
+    <PackageReference Include="Avalonia.Themes.Simple" Version="11.0.0-preview6" />
   </ItemGroup>
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview5" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AvaloniaProgressRing\AvaloniaProgressRing.csproj" />


### PR DESCRIPTION
Hi, I have updated to Avalonia peview-6.

The main difference was that AvaloniaProperty.Register is no longer allowed to use "notifying". Which was the case with the property "IsActiveProperty".

I explicitly asked here for a solution:
https://github.com/AvaloniaUI/Avalonia/discussions/10766

The code looks like more changes than it is, because I don't use spaces but tabs. Should this cause problems in the future it would be useful to provide an "editor.config" which controls the code formatting.